### PR TITLE
Mean wave beat detection

### DIFF
--- a/src/reproimage/utils.py
+++ b/src/reproimage/utils.py
@@ -71,49 +71,252 @@ def confirm_directory(directory: Path):
 
 def mean_wave(x_values, y_values, verbose=False):
     """
-    :param x_values: numpy array of x values
-    :param y_values: numpy array of y values
-    :param verbose: boolean, controls the verbosity of the function
-    :return: a tuple in the form (average wave y values, averaged wave x values)
+    Compute an average beat waveform from a contiguous Doppler waveform.
+
+    Method summary (aligned with current usseg beat logic):
+    1) Propose systolic anchor peaks with prominence-based peak finding and
+       merge peaks that are too close.
+    2) For each anchor peak, build a backward search window in the preceding
+       part of the beat.
+    3) In that window:
+       - smooth the signal,
+       - compute first derivative (slope) and second derivative (change in slope),
+       - find a second-derivative anchor (strongest upslope acceleration),
+       - walk backward on first derivative to the onset of low slope (foot onset).
+    4) Build beats foot-to-foot and derive PS/ED points within each beat for
+       diagnostics.
+    5) Segment foot-to-foot, align beats to a common x-axis, average, remove
+       outlier beats, and recompute the final mean wave.
+
+    :param x_values: numpy array of x values (typically time/sample position).
+    :param y_values: numpy array of y values (waveform amplitude/velocity envelope).
+    :param verbose: boolean controlling diagnostic plotting output.
+    :return: a tuple in the form (average wave y values, averaged wave x values).
     """
+    ### 1) Propose anchor peaks, then merge peaks that are too close.
     wave_amplitude = y_values.max()-y_values.min()
 
-    all_trough_indices, _ = find_peaks(-1*y_values)  # Negate y_values to find minima
-    peak_indices, _ = find_peaks(y_values, prominence=wave_amplitude / 4)  # Negate y_values to find minima
-    ## Want to find the last local minima that has occured before a main peak
-    trough_indices = []
-    for peak in peak_indices:
-        trough_loc = np.where(all_trough_indices<peak)[0].tolist()
-        if trough_loc:
-            trough_loc = trough_loc[-1]
-            trough_indices.append(all_trough_indices[trough_loc])
+    peak_indices, _ = find_peaks(y_values, prominence=wave_amplitude / 4)
+    # Min separation (assume x is time): 200 bpm -> 0.3 s; merge peaks closer than that, keep highest
+    if len(peak_indices) > 1 and len(x_values) >= 2:
+        dx = float(np.median(np.diff(x_values)))
+        if np.isfinite(dx) and dx > 0:
+            min_distance = max(1, int(60.0 / 200.0 / dx))
+            order = np.argsort(peak_indices)
+            peaks = peak_indices[order]
+            consolidated = []
+            i = 0
+            while i < len(peaks):
+                j = i
+                best = int(peaks[i])
+                while j + 1 < len(peaks) and (int(peaks[j + 1]) - int(peaks[j])) <= min_distance:
+                    j += 1
+                    cand = int(peaks[j])
+                    if y_values[cand] > y_values[best]:
+                        best = cand
+                consolidated.append(best)
+                i = j + 1
+            peak_indices = np.array(consolidated, dtype=int)
+    ### 2) For each anchor peak, build a backward search window.
+    ### 3) In each window, detect foot onset via derivative logic.
+    # second-derivative anchor -> backward first-derivative onset threshold.
+    foot_indices = []
+    search_windows = []
+    debug_rows = []
 
+    search_fraction = 0.50
+    smooth_window_max = 11
+    polyorder = 2
+    min_samples_before_peak = 3
+    foot_max_rel_height = 0.55
 
+    for i in range(0, len(peak_indices)):
+        peak = int(peak_indices[i])
+        if i == 0:
+            if len(peak_indices) >= 3:
+                diffs = np.diff(peak_indices).astype(float)
+                other = diffs[1:] if len(diffs) >= 2 else diffs
+                interval_est = int(np.round(np.mean(other))) if other.size > 0 else 0
+            elif len(peak_indices) >= 2:
+                interval_est = int(peak_indices[1] - peak_indices[0])
+            else:
+                interval_est = 0
+            if interval_est < 5:
+                continue
+            interval = int(interval_est)
+            prev_peak = max(0, peak - interval)
+        else:
+            prev_peak = int(peak_indices[i - 1])
+            interval = int(peak - prev_peak)
+        if interval < 5:
+            continue
+
+        local_search_fraction = float(search_fraction) if i == 0 else max(0.0, float(search_fraction) - 0.10)
+        search_len = max(3, int(local_search_fraction * interval))
+        # If first-wave search would extend before signal start, skip this beat.
+        if i == 0 and (peak - search_len) < 0:
+            continue
+        search_start = max(prev_peak, peak - search_len)
+        search_end = max(search_start + 2, peak - int(max(1, min_samples_before_peak)))
+        if search_end <= search_start + 2:
+            continue
+
+        x_region_raw = np.asarray(x_values[search_start:search_end], dtype=float)
+        y_region = y_values[search_start:search_end]
+        if len(y_region) < 3 or x_region_raw.size != len(y_region):
+            continue
+
+        ### 3a) Smooth the local region before derivative calculations.
+        y_smooth = y_region.copy()
+        if len(y_region) >= 5:
+            win = min(smooth_window_max, len(y_region))
+            if win % 2 == 0:
+                win -= 1
+            if win >= 5:
+                y_smooth = savgol_filter(y_region, window_length=win, polyorder=polyorder)
+
+        try:
+            if np.all(np.isfinite(x_region_raw)) and (x_region_raw[-1] > x_region_raw[0]):
+                x_region = np.linspace(float(x_region_raw[0]), float(x_region_raw[-1]), int(len(x_region_raw)))
+                y_for_deriv = np.interp(x_region, x_region_raw, y_smooth)
+            else:
+                x_region = np.arange(search_end - search_start, dtype=float)
+                y_for_deriv = y_smooth
+        except Exception:
+            x_region = np.arange(search_end - search_start, dtype=float)
+            y_for_deriv = y_smooth
+
+        ### 3b) Compute first/second derivatives and smooth d2y.
+        dy = np.gradient(y_for_deriv, x_region)
+        d2y_raw = np.gradient(dy, x_region)
+        d2y = d2y_raw.copy()
+        if len(y_region) >= 5:
+            win_d = min(smooth_window_max, len(y_region))
+            if win_d % 2 == 0:
+                win_d -= 1
+            if win_d >= 5:
+                d2y = savgol_filter(d2y_raw, window_length=win_d, polyorder=polyorder)
+
+        ### 3c) Find second-derivative anchor (maximum upslope acceleration).
+        edge_guard = int(max(0, min(2, (len(d2y) - 1) // 2)))
+        if len(d2y) - (2 * edge_guard) >= 3:
+            d2_core = d2y[edge_guard: len(d2y) - edge_guard]
+            foot2_local = int(edge_guard + np.argmax(d2_core))
+        else:
+            foot2_local = int(np.argmax(d2y))
+
+        ### 3d) Walk backward on dy to find low-slope foot onset.
+        dy_seg = dy[: foot2_local + 1]
+        if dy_seg.size == 0:
+            continue
+        dy_max = float(np.max(dy_seg))
+        picked_local = int(foot2_local)
+        slope_thr = np.nan
+        if np.isfinite(dy_max) and dy_max > 0:
+            slope_thr = 0.08 * dy_max
+            for j in range(int(foot2_local), -1, -1):
+                if float(dy[j]) <= float(slope_thr):
+                    picked_local = int(j)
+                    break
+        picked = int(search_start + picked_local)
+
+        ### 3e) Apply morphology guardrails and fallback if needed.
+        try:
+            trough_y = float(np.min(y_values[prev_peak:peak])) if peak > prev_peak + 1 else float(y_values[prev_peak])
+            peak_y = float(y_values[peak])
+        except Exception:
+            trough_y = float(np.min(y_region))
+            peak_y = float(np.max(y_region))
+        allowed_y = trough_y + float(foot_max_rel_height) * (peak_y - trough_y)
+        needs_fallback = (
+            picked < 0
+            or picked >= len(y_values)
+            or picked >= peak - int(max(1, min_samples_before_peak))
+            or float(y_values[picked]) > allowed_y
+        )
+        if needs_fallback:
+            seg_pre = y_values[search_start: search_start + foot2_local + 1]
+            if seg_pre.size > 0:
+                picked = int(search_start + int(np.argmin(seg_pre)))
+            else:
+                picked = int(search_start + foot2_local)
+
+        foot_indices.append(picked)
+        search_windows.append((search_start, search_end))
+        debug_rows.append(
+            {
+                "search_start": int(search_start),
+                "search_end": int(search_end),
+                "foot2_global": int(search_start + foot2_local),
+                "picked_global": int(picked),
+                "dy": np.asarray(dy, dtype=float),
+                "d2y": np.asarray(d2y, dtype=float),
+                "slope_thr": float(slope_thr) if np.isfinite(slope_thr) else np.nan,
+            }
+        )
+
+    foot_indices = np.asarray(foot_indices, dtype=int)
+    if len(foot_indices) < 2:
+        raise ValueError("Not enough foot points found to calculate mean wave.")
+    ### 4) Build foot-to-foot beats and derive PS/ED points.
+    y_s = np.asarray(y_values, dtype=float)
+    if len(y_values) >= 5:
+        y_s = np.convolve(y_values, np.ones(5) / 5.0, mode="same")
+    ps_indices = []
+    ed_indices = []
+    for i in range(len(foot_indices) - 1):
+        a = int(foot_indices[i])
+        b = int(foot_indices[i + 1])
+        if b <= a + 2:
+            continue
+        seg = y_s[a:b]
+        anchor_in_beat = peak_indices[(peak_indices >= a) & (peak_indices < b)]
+        ps_idx = None
+        if anchor_in_beat.size > 0:
+            aa = anchor_in_beat[np.argmax(y_s[anchor_in_beat])]
+            ps_idx = int(aa)
+            ps_indices.append(ps_idx)
+        else:
+            ps_idx = int(a + int(np.argmax(seg)))
+            ps_indices.append(ps_idx)
+
+        # ED is constrained to occur after PS within the same beat.
+        ed_start = int(max(a, ps_idx + 1))
+        if ed_start < b:
+            seg_ed = y_s[ed_start:b]
+            if seg_ed.size > 0:
+                ed_indices.append(int(ed_start + int(np.argmin(seg_ed))))
+                continue
+        # Fallback for very short post-PS segments.
+        ed_indices.append(int(a + int(np.argmin(seg))))
+    segment_indices = foot_indices
+
+    ### 5) Segment, align, average, filter outliers, and recompute mean wave.
     interpolated_waves = []
     if verbose:
-        plt.figure(figsize=(10, 6))
-        plt.plot(x_values, y_values, label="Waveform", color='blue')
-        plt.scatter(x_values[all_trough_indices], y_values[all_trough_indices], color='blue', label='Troughs', zorder=5)
-        plt.scatter(x_values[peak_indices], y_values[peak_indices], color='black', label='Peaks', zorder=5)
-        plt.scatter(x_values[trough_indices], y_values[trough_indices], color='red', label='Final Troughs', zorder=5)
+        _plot_detection_diagnostics(
+            x_values=x_values,
+            y_values=y_values,
+            peak_indices=peak_indices,
+            foot_indices=foot_indices,
+            ps_indices=ps_indices,
+            ed_indices=ed_indices,
+            search_windows=search_windows,
+            debug_rows=debug_rows,
+            smooth_window_max=smooth_window_max,
+            polyorder=polyorder,
+        )
 
-        plt.title("Waveform with Trough Points")
-        plt.xlabel("Time")
-        plt.ylabel("Amplitude")
-        plt.legend()
-        plt.grid(True)
-        plt.show()
-
-    for i in range(len(trough_indices) - 1):
+    for i in range(len(segment_indices) - 1):
         # Extract data for the current segment
-        start_index = trough_indices[i]
-        end_index = trough_indices[i + 1]
+        start_index = segment_indices[i]
+        end_index = segment_indices[i + 1]
         x_segment = x_values[start_index:end_index]
         y_segment = y_values[start_index:end_index]
 
         # Shift x-coordinates for alignment (except the first wave)
         if i > 0:
-            x_segment = x_segment - (x_segment[0] - x_values[trough_indices[0]])
+            x_segment = x_segment - (x_segment[0] - x_values[segment_indices[0]])
 
         # Initialize the common x-axis using the first segment
         if i == 0:
@@ -135,18 +338,7 @@ def mean_wave(x_values, y_values, verbose=False):
     amplitude_of_ave = np.max(average_wave)-np.min(average_wave)
 
     if verbose:
-        plt.figure(figsize=(10, 6))
-        plt.title("Set of Waveforms")
-        plt.xlabel("Time")
-        plt.ylabel("Amplitude")
-        for wave_index, waveform in enumerate(interpolated_waves):
-            plt.plot(x_common, waveform, label=f"Waveform {wave_index}")
-        plt.plot(x_common, average_wave, label='Average wave', linestyle='-.')
-        plt.plot(x_common, average_wave+std_wave, label='Average wave + SD', linestyle='--')
-        plt.plot(x_common, average_wave-std_wave, label='Average wave - SD', linestyle='--')
-        plt.legend()
-        plt.grid(True)
-        plt.show()
+        _plot_wave_set(x_common, interpolated_waves, average_wave, std_wave)
 
     # Filter out waves outside the range of average ± standard deviation
     threshold_percentage = 80
@@ -163,7 +355,7 @@ def mean_wave(x_values, y_values, verbose=False):
         if percentage_within_range >= threshold_percentage:
             filtered_waves.append(wave)
         else:
-            count_excluded =+ 1
+            count_excluded += 1
             excluded_waves.append(wave)
     if verbose:
         print("Waves filtered, num excluded", count_excluded)
@@ -177,14 +369,7 @@ def mean_wave(x_values, y_values, verbose=False):
     new_average_wave = np.mean(filtered_waves_np, axis=0)
     new_std_wave = np.std(filtered_waves_np, axis=0)
     if verbose:
-        plt.figure(figsize=(10, 6))
-        plt.title("Average waveform")
-        plt.xlabel("Time")
-        plt.ylabel("Amplitude")
-        plt.plot(x_common, new_average_wave)
-        #plt.plot(x_common, excluded_waves[0])
-        plt.grid(True)
-        plt.show()
+        _plot_average_wave(x_common, new_average_wave)
 
     return new_average_wave, x_common
 

--- a/src/reproimage/utils.py
+++ b/src/reproimage/utils.py
@@ -2,7 +2,7 @@ import inspect
 
 import numpy as np
 from pathlib import Path
-from scipy.signal import find_peaks
+from scipy.signal import find_peaks, savgol_filter
 from scipy.interpolate import interp1d
 from matplotlib import pyplot as plt
 import sqlite3
@@ -187,6 +187,277 @@ def mean_wave(x_values, y_values, verbose=False):
         plt.show()
 
     return new_average_wave, x_common
+
+
+def _plot_detection_diagnostics(
+    x_values,
+    y_values,
+    peak_indices,
+    foot_indices,
+    ps_indices,
+    ed_indices,
+    search_windows,
+    debug_rows,
+    smooth_window_max,
+    polyorder,
+):
+    """
+    Plot diagnostic panels for beat-foot detection and derivative-based anchors.
+
+    :param x_values: 1D numpy array of x-axis values for the waveform.
+    :param y_values: 1D numpy array of waveform amplitudes.
+    :param peak_indices: 1D integer array of anchor peak indices.
+    :param foot_indices: 1D integer array of detected foot indices.
+    :param ps_indices: List/array of peak systolic (PS) indices per beat.
+    :param ed_indices: List/array of end-diastolic (ED) indices per beat.
+    :param search_windows: List of (start, end) index tuples used as foot search regions.
+    :param debug_rows: List of dictionaries containing per-beat debug values
+    (search bounds, selected indices, and slope thresholds).
+    :param smooth_window_max: Integer max odd window size used for Savitzky-Golay smoothing.
+    :param polyorder: Polynomial order for Savitzky-Golay smoothing.
+    :return: None. Shows matplotlib figures for interactive diagnostics.
+    """
+    fig, (ax1, ax2, ax3) = plt.subplots(
+        3,
+        1,
+        figsize=(11, 10),
+        sharex=True,
+        gridspec_kw={"height_ratios": [2, 1, 1]},
+    )
+
+    y_smooth_global = y_values.copy()
+    if len(y_values) >= 5:
+        win_g = min(smooth_window_max, len(y_values))
+        if win_g % 2 == 0:
+            win_g -= 1
+        if win_g >= 5:
+            y_smooth_global = savgol_filter(
+                y_values, window_length=win_g, polyorder=polyorder
+            )
+
+    ax1.plot(x_values, y_values, label="Waveform", color="blue")
+    ax1.plot(
+        x_values,
+        y_smooth_global,
+        label="Smoothed (for derivatives)",
+        color="C1",
+        linewidth=1.2,
+        alpha=0.9,
+    )
+    ax1.scatter(
+        x_values[peak_indices],
+        y_values[peak_indices],
+        color="black",
+        label="Peaks",
+        zorder=5,
+    )
+    ax1.scatter(
+        x_values[foot_indices],
+        y_values[foot_indices],
+        color="red",
+        label="Detected feet",
+        zorder=6,
+    )
+    if len(ps_indices) > 0:
+        ax1.scatter(
+            x_values[np.asarray(ps_indices, dtype=int)],
+            y_values[np.asarray(ps_indices, dtype=int)],
+            color="C2",
+            s=26,
+            marker="^",
+            label="PS (foot-beat)",
+            zorder=7,
+        )
+    if len(ed_indices) > 0:
+        ax1.scatter(
+            x_values[np.asarray(ed_indices, dtype=int)],
+            y_values[np.asarray(ed_indices, dtype=int)],
+            color="C3",
+            s=26,
+            marker="v",
+            label="ED (foot-beat)",
+            zorder=7,
+        )
+    for k, (s, e) in enumerate(search_windows):
+        ax1.axvspan(
+            x_values[s],
+            x_values[e - 1],
+            color="orange",
+            alpha=0.12,
+            label="Search window" if k == 0 else None,
+        )
+    if foot_indices.size > 0:
+        fp = np.asarray(foot_indices, dtype=int)
+        fp = fp[(fp >= 0) & (fp < len(x_values))]
+        if fp.size > 0:
+            if int(fp[0]) > 0:
+                ax1.axvspan(
+                    x_values[0],
+                    x_values[int(fp[0])],
+                    color="#ff6b6b",
+                    alpha=0.08,
+                    zorder=0,
+                    label="Incomplete region",
+                )
+            ap = np.asarray(peak_indices, dtype=int)
+            ap = ap[(ap >= 0) & (ap < len(x_values))]
+            if ap.size > 0 and int(ap[-1]) > int(fp[-1]):
+                ax1.axvspan(
+                    x_values[int(fp[-1])],
+                    x_values[-1],
+                    color="#ff6b6b",
+                    alpha=0.08,
+                    zorder=0,
+                    label=None,
+                )
+    ax1.set_title("Waveform with anchor peaks, feet, PS and ED")
+    ax1.set_ylabel("Amplitude")
+    ax1.legend()
+    ax1.grid(True)
+
+    dy_g = np.gradient(y_smooth_global, x_values)
+    d2y_g = np.gradient(dy_g, x_values)
+    ax2.axhline(0.0, color="0.7", linewidth=1)
+    ax2.plot(
+        x_values,
+        dy_g,
+        linestyle="-",
+        linewidth=1.2,
+        label="First derivative (dy/dx) of smoothed signal",
+    )
+    for k, (s, e) in enumerate(search_windows):
+        ax2.axvspan(
+            x_values[s],
+            x_values[e - 1],
+            color="orange",
+            alpha=0.12,
+            label="Search window" if k == 0 else None,
+        )
+
+    for k, row in enumerate(debug_rows):
+        s = int(row["search_start"])
+        e = int(row["search_end"])
+        ub = int(row["foot2_global"])
+        picked = int(row["picked_global"])
+        slope_thr = float(row["slope_thr"]) if np.isfinite(row["slope_thr"]) else np.nan
+        if s < 0 or e <= s or e > len(x_values):
+            continue
+        if np.isfinite(slope_thr):
+            ax2.plot(
+                [x_values[s], x_values[e - 1]],
+                [slope_thr, slope_thr],
+                ":",
+                color="gray",
+                alpha=0.7,
+                label="dy threshold" if k == 0 else None,
+            )
+        if 0 <= ub < len(x_values):
+            ax2.scatter(
+                [x_values[ub]],
+                [dy_g[ub]],
+                marker="s",
+                facecolors="none",
+                edgecolors="black",
+                s=24,
+                label="Second-derivative anchor" if k == 0 else None,
+                zorder=6,
+            )
+        if 0 <= picked < len(x_values):
+            ax2.scatter(
+                [x_values[picked]],
+                [dy_g[picked]],
+                marker="D",
+                color="red",
+                s=22,
+                label="Selected foot (low-slope onset)" if k == 0 else None,
+                zorder=7,
+            )
+
+    ax2.set_title("First derivative with second-derivative anchors and selected feet")
+    ax2.set_ylabel("First derivative (dy/dx)")
+    ax2.legend()
+    ax2.grid(True)
+
+    ax3.axhline(0.0, color="0.7", linewidth=1)
+    ax3.plot(
+        x_values,
+        d2y_g,
+        linestyle="-",
+        linewidth=1.2,
+        label="Second derivative (d²y/dx²) of smoothed signal",
+    )
+    for k, (s, e) in enumerate(search_windows):
+        ax3.axvspan(
+            x_values[s],
+            x_values[e - 1],
+            color="orange",
+            alpha=0.12,
+            label="Search window" if k == 0 else None,
+        )
+
+    for k, row in enumerate(debug_rows):
+        ub = int(row["foot2_global"])
+        if 0 <= ub < len(x_values):
+            ax3.scatter(
+                [x_values[ub]],
+                [d2y_g[ub]],
+                marker="s",
+                facecolors="none",
+                edgecolors="black",
+                s=24,
+                label="Second-derivative anchor" if k == 0 else None,
+                zorder=6,
+            )
+
+    ax3.set_title("Second derivative with anchor points")
+    ax3.set_xlabel("Time")
+    ax3.set_ylabel("Second derivative (d²y/dx²)")
+    ax3.legend()
+    ax3.grid(True)
+
+    fig.tight_layout()
+    plt.show()
+
+
+def _plot_wave_set(x_common, interpolated_waves, average_wave, std_wave):
+    """
+    Plot aligned beat waveforms with their mean and +/- 1 standard deviation.
+
+    :param x_common: 1D numpy array of common x-axis points used after interpolation.
+    :param interpolated_waves: Iterable of 1D arrays representing aligned beat waveforms.
+    :param average_wave: 1D numpy array containing the pointwise mean waveform.
+    :param std_wave: 1D numpy array containing the pointwise waveform standard deviation.
+    :return: None. Shows a matplotlib figure.
+    """
+    plt.figure(figsize=(10, 6))
+    plt.title("Set of Waveforms")
+    plt.xlabel("Time")
+    plt.ylabel("Amplitude")
+    for wave_index, waveform in enumerate(interpolated_waves):
+        plt.plot(x_common, waveform, label=f"Waveform {wave_index}")
+    plt.plot(x_common, average_wave, label='Average wave', linestyle='-.')
+    plt.plot(x_common, average_wave + std_wave, label='Average wave + SD', linestyle='--')
+    plt.plot(x_common, average_wave - std_wave, label='Average wave - SD', linestyle='--')
+    plt.legend()
+    plt.grid(True)
+    plt.show()
+
+
+def _plot_average_wave(x_common, new_average_wave):
+    """
+    Plot the final averaged waveform after outlier-beat filtering.
+
+    :param x_common: 1D numpy array of common x-axis points.
+    :param new_average_wave: 1D numpy array of final averaged waveform values.
+    :return: None. Shows a matplotlib figure.
+    """
+    plt.figure(figsize=(10, 6))
+    plt.title("Average waveform")
+    plt.xlabel("Time")
+    plt.ylabel("Amplitude")
+    plt.plot(x_common, new_average_wave)
+    plt.grid(True)
+    plt.show()
 
 
 class MetaData:


### PR DESCRIPTION
Implemented a robust foot-to-foot beat segmentation update in `mean_wave()`, replacing the prior “last local minimum before peak” method.

The new method uses a hybrid derivative approach: it finds a pre-peak candidate foot region, uses the signal second derivative maximum as an upslope anchor, then traces backward on the signal first derivative to identify low-slope onset (foot), with plausibility checks and fallback handling for noisy/edge cases.

`verbose = True` now plots the derivative method figure:
<img width="1662" height="1068" alt="image" src="https://github.com/user-attachments/assets/b4f6c5e9-c6d3-4ea8-abb1-ccc438b9fee1" />

Along with the pre-existing overlay and mean:

<img width="861" height="547" alt="image" src="https://github.com/user-attachments/assets/6aea2dfe-45ed-4231-9f7b-d66b9582b252" />
